### PR TITLE
Avoid exporting empty layers (UN-5409)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,10 @@ jobs:
       #    - name: Install Qt lrelease
       #      run: sudo apt-get install qt5-default qttools5-dev-tools
 
-      # sets up an "environment" tag that will be read and used by Sentry when
-      # reporting errors (see sentry.py for more details)
-      - name: Set Sentry environment
+      # sets up an "environment" tag for Sentry
+      - name: Set up a Sentry environment
         run: |
-          echo "production" > Unfolded/sentry_env
+          sed -i '' "s/PLUGIN_ENVIRONMENT='local'/PLUGIN_ENVIRONMENT='production'/" Unfolded/sentry.py
 
       - name: Install qgis-plugin-ci
         run: pip3 install qgis-plugin-ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
       #    - name: Install Qt lrelease
       #      run: sudo apt-get install qt5-default qttools5-dev-tools
 
+      # sets up an "environment" tag that will be read and used by Sentry when
+      # reporting errors (see sentry.py for more details)
+      - name: Set Sentry environment
+        run: |
+          echo "production" > Unfolded/sentry_env
+
       - name: Install qgis-plugin-ci
         run: pip3 install qgis-plugin-ci
 

--- a/Unfolded/core/config_creator.py
+++ b/Unfolded/core/config_creator.py
@@ -262,19 +262,25 @@ class ConfigCreator(QObject):
                 elif isinstance(task, LayerToLayerConfig):
                     layers[layer_uuids.index(task.layer_uuid)] = task.result_layer_conf
 
-            field_formats = {}
-            for dataset in datasets:
-                dataId = str(dataset.data.id)
-                field_formats[dataId] = {}
-                for field in dataset.data.fields:
-                    field_formats[dataId][field.name] = field.format
+            tooltip_data = {}
+            for layer_uuid, fields in self._shown_fields.items():
+                field_list = []
+                for field_name in fields:
+                    # try to find a field in a dataset so we can get its format
+                    datasetIdx = layer_uuids.index(task.layer_uuid)
+                    dataset = datasets[datasetIdx]
+                    for dataset_field in dataset.data.fields:
+                        if dataset_field.name == field_name:
+                            field_list.append({"name": field_name, "format": dataset_field.format})
 
-            tooltip = Tooltip(FieldsToShow(AnyDict(
-                {layer_uuid: [{"name": name, "format": field_formats[layer_uuid][name]} for name in fields] for
-                 layer_uuid, fields in
-                 self._shown_fields.items()})), Tooltip.compare_mode,
+                tooltip_data[layer_uuid] = field_list
+
+            tooltip = Tooltip(
+                FieldsToShow(AnyDict(tooltip_data)),
+                Tooltip.compare_mode,
                 Tooltip.compare_type,
-                self._interaction_config_values["tooltip_enabled"])
+                self._interaction_config_values["tooltip_enabled"]
+            )
 
             interaction_config = InteractionConfig(tooltip, self._interaction_config_values["brush"],
                                                    self._interaction_config_values["geocoder"],

--- a/Unfolded/sentry.py
+++ b/Unfolded/sentry.py
@@ -32,6 +32,16 @@ def init_sentry():
         traces_sample_rate=0.1,
     )
 
+    env = 'local'
+    try:
+        # we set this in the release GHA workflow for prod
+        sentry_env_file = open(os.path.join(os.path.dirname(__file__), 'sentry_env'))
+        env = sentry_env_file.readline()
+        sentry_env_file.close()
+    except:
+        pass
+
+    sentry_sdk.set_tag('environment', env)
     sentry_sdk.set_tag('version', PLUGIN_VERSION)
     sentry_sdk.set_tag('platform.platform', platform.platform())
     sentry_sdk.set_tag('platform.system', platform.system())

--- a/Unfolded/sentry.py
+++ b/Unfolded/sentry.py
@@ -24,7 +24,8 @@ except:
     pip.main(['install', 'sentry-sdk==1.24.0'])
     import sentry_sdk
 
-PLUGIN_VERSION = '1.0.4'
+PLUGIN_VERSION='1.0.4'
+PLUGIN_ENVIRONMENT='local'
 
 def init_sentry():
     sentry_sdk.init(
@@ -32,16 +33,7 @@ def init_sentry():
         traces_sample_rate=0.1,
     )
 
-    env = 'local'
-    try:
-        # we set this in the release GHA workflow for prod
-        sentry_env_file = open(os.path.join(os.path.dirname(__file__), 'sentry_env'))
-        env = sentry_env_file.readline()
-        sentry_env_file.close()
-    except:
-        pass
-
-    sentry_sdk.set_tag('environment', env)
+    sentry_sdk.set_tag('environment', PLUGIN_ENVIRONMENT)
     sentry_sdk.set_tag('version', PLUGIN_VERSION)
     sentry_sdk.set_tag('platform.platform', platform.platform())
     sentry_sdk.set_tag('platform.system', platform.system())

--- a/Unfolded/ui/export_panel.py
+++ b/Unfolded/ui/export_panel.py
@@ -21,11 +21,11 @@ import logging
 import uuid
 import webbrowser
 from pathlib import Path
-from typing import Optional, Tuple, List
+from typing import Optional, Tuple, List, cast
 
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QComboBox, QTableWidget, QTableWidgetItem, QCheckBox
-from qgis.core import QgsProject, QgsVectorLayer, QgsApplication
+from qgis.core import QgsProject, QgsVectorLayer, QgsApplication, QgsMapLayer
 from qgis.gui import QgsMapCanvas
 from qgis.utils import iface
 
@@ -137,7 +137,15 @@ class ExportPanel(BasePanel):
                 if not layers:
                     raise ExportException(tr('No layers found with name {}!', layer_name),
                                           bar_msg=bar_msg(tr('Open the dialog again to refresh the layers')))
-                layers_with_visibility.append((layers[0], is_visible))
+
+                if layers[0].type() != QgsMapLayer.VectorLayer:
+                    LOGGER.warning(tr('Skipping layer {} because it is not a vector layer', layers[0].name()))
+
+                layer = cast(QgsVectorLayer, layers[0])
+                if layer.featureCount() == 0:
+                    LOGGER.warning(tr('Skipping layer {} because it is empty', layer.name()))
+                else:
+                    layers_with_visibility.append((layer, is_visible))
         if not layers_with_visibility:
             raise ExportException(tr('No layers selected'),
                                   bar_msg=bar_msg(tr('Select at least on layer to continue export')))

--- a/Unfolded/ui/export_panel.py
+++ b/Unfolded/ui/export_panel.py
@@ -140,12 +140,14 @@ class ExportPanel(BasePanel):
 
                 if layers[0].type() != QgsMapLayer.VectorLayer:
                     LOGGER.warning(tr('Skipping layer {} because it is not a vector layer', layers[0].name()))
+                    continue
 
                 layer = cast(QgsVectorLayer, layers[0])
                 if layer.featureCount() == 0:
                     LOGGER.warning(tr('Skipping layer {} because it is empty', layer.name()))
-                else:
-                    layers_with_visibility.append((layer, is_visible))
+                    continue
+
+                layers_with_visibility.append((layer, is_visible))
         if not layers_with_visibility:
             raise ExportException(tr('No layers selected'),
                                   bar_msg=bar_msg(tr('Select at least on layer to continue export')))


### PR DESCRIPTION
Ticket: [UN-5409](https://foursquare.atlassian.net/browse/UN-5409)

We now skip some layers that we cannot handle or Studio would complain about - those that are not vector layers (`QgsVectorLayer`) and those that are empty (zero features).

**Testing**

- download and install extension [Unfolded-dev.zip](https://github.com/foursquare/qgis-plugin/files/11677484/Unfolded-dev.zip) (from `3fd7c95`)
- test both test files from the ticket (one by one)
- export projects via plugin and import them to Studio
- verify they load in the Studio without any errors, and look the same

**Notes**

An extra fix was put in place how some field data is getting indexed, because during the processing of such large projects and layers, multithreaded characteristics of processing kick in and some data structures were out of order.

[UN-5409]: https://foursquare.atlassian.net/browse/UN-5409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ