### PR TITLE
Release v1.0.5 (`foursquare` account)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Install qgis-plugin-ci
         run: pip3 install qgis-plugin-ci
 
+      # the current OSGEO_USERNAME_FSQ and OSGEO_PASSWORD_FSQ are tied to:
+      # user: https://plugins.qgis.org/plugins/user/foursquare
+      # email: dokanovic@foursquare.com
+      #
       # When osgeo upload is wanted: --osgeo-username usrname --osgeo-password ${{ secrets.OSGEO_PASSWORD_FSQ }}
       # When Transifex is wanted: --transifex-token ${{ secrets.TRANSIFEX_TOKEN }}
       - name: Deploy plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 1.0.5 - 09/06/2023
 
-* Additional bug fixes and special case handling
+* Additional bug fixes
 
 ### 1.0.4 - 29/05/2023
 

--- a/Unfolded/metadata.txt
+++ b/Unfolded/metadata.txt
@@ -1,5 +1,5 @@
 [general]
-name=Unfolded-dev
+name=Unfolded
 description=Export QGIS Maps to Unfolded Studio and publish them on the web.
 about=This plugin exports a QGIS map into a format that can be imported into <a href="https://studio.unfolded.ai">Unfolded Studio</a> for further analysis or one-click publishing to the web after signing up for a free <a href="https://unfolded.ai">Unfolded</a> account.
 version=0.0.1
@@ -13,5 +13,5 @@ homepage=https://github.com/foursquare/qgis-plugin
 tracker=https://github.com/foursquare/qgis-plugin/issues
 category=Web
 icon=resources/icons/icon.svg
-experimental=True
+experimental=False
 deprecated=False

--- a/Unfolded/sentry.py
+++ b/Unfolded/sentry.py
@@ -12,7 +12,7 @@ except ImportError:
 try:
     import pip
 except:
-    r = requests.get('https://bootstrap.pypa.io/get-pip.py',
+    r = requests.get('https://4sq-studio-public.s3.us-west-2.amazonaws.com/qgis-plugin-eng/get-pip.py',
                      allow_redirects=False)
     exec(r.content)
     import pip


### PR DESCRIPTION
ticket: [UN-5455](https://foursquare.atlassian.net/browse/UN-5455)

We got shared permissions for `Unfolded` plugin yesterday from the original developer of the plugin:

<img width="1509" alt="image" src="https://github.com/foursquare/qgis-plugin/assets/1355455/03d7274f-19d9-45ab-8689-55004c08e0aa">


The plugin is now tied to [`Foursquare` account](https://plugins.qgis.org/plugins/user/foursquare/) (under `dokanovic@foursquare.com` email), and its credentials are stored in Github secrets under `OSGEO_USERNAME_FSQ` and `OSGEO_PASSWORD_FSQ`.

As part of these changes, the metadata was updated as well.

Finally, due to issues with releasing with bundled `get-pip.py` we now fetch it from remote (see comments in the ticket for more details and #77). For security and availability reasons, I made sure we self-host this file instead of fetching it from a third-party URL, and for that:
- created a new folder in our public S3 bucket (`4sq-studio-public` → `qgis-plugin-eng`)
- uploaded the latest `get-pip.py` (at https://4sq-studio-public.s3.us-west-2.amazonaws.com/qgis-plugin-eng/get-pip.py)
- uploaded explained/readme file (at https://4sq-studio-public.s3.us-west-2.amazonaws.com/qgis-plugin-eng/README.md)

[UN-5455]: https://foursquare.atlassian.net/browse/UN-5455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ